### PR TITLE
fix: unrecognized field "classifier" in Nexus 3.19 API response

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Maven2.java
+++ b/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Maven2.java
@@ -1,5 +1,8 @@
 package org.jenkinsci.plugins.maven_artifact_choicelistprovider.nexus3;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Maven2 {
 
     private String extension;


### PR DESCRIPTION
Nexus 3.29.1 release returns additional fields in API response.
```
WARNING o.j.p.m.n.Nexus3RestApiSearchService#callService: failed to map
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "classifier" (class org.jenkinsci.plugins.maven_artifact_choicelistprovider.nexus3.Maven2), not marked as ignorable (4 known properties: "version", "groupId", "artifactId", "extension"])
```

I think it's safe to ignore those fields.