### PR TITLE
Establish additional regexp filter based artifact selection

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/AbstractMavenArtifactDescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/AbstractMavenArtifactDescriptorImpl.java
@@ -49,14 +49,17 @@ public abstract class AbstractMavenArtifactDescriptorImpl extends Descriptor<Cho
     }
 
     public FormValidation performTest(final IVersionReader pService, @QueryParameter String repositoryId, @QueryParameter String groupId, @QueryParameter String artifactId,
-            @QueryParameter String packaging, @QueryParameter String classifier, @QueryParameter boolean reverseOrder) {
+            @QueryParameter String packaging, @QueryParameter String classifier,
+            @QueryParameter boolean inverseFilter, @QueryParameter String filterExpression, @QueryParameter boolean reverseOrder) {
         if (StringUtils.isEmpty(packaging) && !StringUtils.isEmpty(classifier)) {
             return FormValidation
                     .error("You have choosen an empty Packaging configuration but have configured a Classifier. Please either define a Packaging value or remove the Classifier");
         }
 
+        //TODO error handling of invalid regexp syntax
+
         try {
-            final Map<String, String> entriesFromURL = wrapTestConnection(pService, repositoryId, groupId, artifactId, packaging, classifier, reverseOrder);
+            final Map<String, String> entriesFromURL = wrapTestConnection(pService, repositoryId, groupId, artifactId, packaging, classifier, inverseFilter, filterExpression, reverseOrder);
 
             if (entriesFromURL.isEmpty()) {
                 return FormValidation.ok("(Working, but no Entries found)");
@@ -84,11 +87,15 @@ public abstract class AbstractMavenArtifactDescriptorImpl extends Descriptor<Cho
      *            TBD
      * @param classifier
      *            TBD
+     * @param inverseFilter
+     *            TBD
+     * @param filterExpression
+     *            TBD
      * @param reverseOrder
      *            TBD
      * @return the list of found items.
      */
     protected abstract Map<String, String> wrapTestConnection(IVersionReader service, String repositoryId, String groupId, String artifactId, String packaging, String classifier,
-            boolean reverseOrder);
+            boolean inverseFilter, String filterExpression, boolean reverseOrder);
 
 }

--- a/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/AbstractRESTfulVersionReader.java
+++ b/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/AbstractRESTfulVersionReader.java
@@ -96,7 +96,7 @@ public abstract class AbstractRESTfulVersionReader implements IVersionReader {
 			}
 			throw new VersionReaderException(msg, e);
 		} catch (Exception e) {
-			if (e instanceof SSLHandshakeException) {
+			if (e.getCause() instanceof SSLHandshakeException) {
 				throw new VersionReaderException("The certificate of the target repository is untrusted by this JVM",
 						e);
 			} else if (e instanceof ProcessingException) {

--- a/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider.java
@@ -69,7 +69,8 @@ public class ArtifactoryChoiceListProvider extends AbstractMavenArtifactChoiceLi
 
         @POST
         public FormValidation doTest(@AncestorInPath Item pItem, @QueryParameter String url, @QueryParameter String credentialsId, @QueryParameter String groupId,
-                @QueryParameter String artifactId, @QueryParameter String packaging, @QueryParameter String classifier, @QueryParameter boolean reverseOrder) {
+                @QueryParameter String artifactId, @QueryParameter String packaging, @QueryParameter String classifier,
+                @QueryParameter boolean inverseFilter, @QueryParameter String filterExpression, @QueryParameter boolean reverseOrder) {
 
             // SECURITY-1022
             pItem.checkPermission(Job.CONFIGURE);
@@ -81,13 +82,13 @@ public class ArtifactoryChoiceListProvider extends AbstractMavenArtifactChoiceLi
             if (c != null) {
                 service.setCredentials(c.getUsername(), c.getPassword().getPlainText());
             }
-            return super.performTest(service, "", groupId, artifactId, packaging, classifier, reverseOrder);
+            return super.performTest(service, "", groupId, artifactId, packaging, classifier, inverseFilter, filterExpression, reverseOrder);
         }
 
         @Override
         protected Map<String, String> wrapTestConnection(IVersionReader pService, String pRepositoryId, String pGroupId, String pArtifactId, String pPackaging, String pClassifier,
-                boolean pReverseOrder) {
-            return readURL(pService, pRepositoryId, pGroupId, pArtifactId, pPackaging, pClassifier, pReverseOrder);
+                boolean pInverseFilter, String pFilterExpression, boolean pReverseOrder) {
+            return readURL(pService, pRepositoryId, pGroupId, pArtifactId, pPackaging, pClassifier, pInverseFilter, pFilterExpression, pReverseOrder);
         }
 
         public FormValidation doCheckUrl(@QueryParameter String url) {

--- a/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider.java
@@ -43,16 +43,16 @@ public class MavenCentralChoiceListProvider extends AbstractMavenArtifactChoiceL
 
 		public FormValidation doTest(@QueryParameter String url, @QueryParameter String groupId,
 				@QueryParameter String artifactId, @QueryParameter String packaging, @QueryParameter String classifier,
-				@QueryParameter boolean reverseOrder) {
+				@QueryParameter boolean inverseFilter, @QueryParameter String filterExpression, @QueryParameter boolean reverseOrder) {
 			final IVersionReader service = new MavenCentralSearchService();
-			return super.performTest(service, "", groupId, artifactId, packaging, classifier, reverseOrder);
+			return super.performTest(service, "", groupId, artifactId, packaging, classifier, inverseFilter, filterExpression, reverseOrder);
 		}
 
 		@Override
 		protected Map<String, String> wrapTestConnection(IVersionReader service, String pRepositoryId, String pGroupId, String pArtifactId,
-				String pPackaging, String pClassifier, boolean pReverseOrder) {
+				String pPackaging, String pClassifier, boolean pInverseFilter, String pFilterExpression, boolean pReverseOrder) {
 			return readURL(new MavenCentralSearchService(), pRepositoryId, pGroupId, pArtifactId, pPackaging, pClassifier,
-					pReverseOrder);
+					pInverseFilter, pFilterExpression, pReverseOrder);
 		}
 
 	}

--- a/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider.java
@@ -83,7 +83,7 @@ public class NexusChoiceListProvider extends AbstractMavenArtifactChoiceListProv
         @POST
         public FormValidation doTest(@AncestorInPath Item pItem, @QueryParameter String url, @QueryParameter String credentialsId, @QueryParameter String repositoryId,
                 @QueryParameter String groupId, @QueryParameter String artifactId, @QueryParameter String packaging, @QueryParameter String classifier,
-                @QueryParameter boolean reverseOrder) {
+                @QueryParameter boolean inverseFilter, @QueryParameter String filterExpression, @QueryParameter boolean reverseOrder) {
 
             // SECURITY-1022
             pItem.checkPermission(Job.CONFIGURE);
@@ -95,13 +95,14 @@ public class NexusChoiceListProvider extends AbstractMavenArtifactChoiceListProv
             if (c != null) {
                 service.setCredentials(c.getUsername(), c.getPassword().getPlainText());
             }
-            return super.performTest(service, repositoryId, groupId, artifactId, packaging, classifier, reverseOrder);
+            return super.performTest(service, repositoryId, groupId, artifactId, packaging, classifier, inverseFilter, filterExpression, reverseOrder);
         }
 
         @Override
         protected Map<String, String> wrapTestConnection(IVersionReader pService, String pRepositoryId, String pGroupId, String pArtifactId, String pPackaging, String pClassifier,
-                boolean pReverseOrder) {
-            return readURL(pService, pRepositoryId, pGroupId, pArtifactId, pPackaging, pClassifier, pReverseOrder);
+                boolean pInverseFilter, String pFilterExpression, boolean pReverseOrder) {
+            return readURL(pService, pRepositoryId, pGroupId, pArtifactId, pPackaging, pClassifier,
+                pInverseFilter, pFilterExpression, pReverseOrder);
         }
 
         public FormValidation doCheckUrl(@QueryParameter String url) {

--- a/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider.java
@@ -77,7 +77,7 @@ public class Nexus3ChoiceListProvider extends AbstractMavenArtifactChoiceListPro
         @POST
         public FormValidation doTest(@AncestorInPath Item pItem, @QueryParameter String url, @QueryParameter String credentialsId, @QueryParameter String repositoryId,
                 @QueryParameter String groupId, @QueryParameter String artifactId, @QueryParameter String packaging, @QueryParameter String classifier,
-                @QueryParameter boolean reverseOrder) {
+                @QueryParameter boolean inverseFilter, @QueryParameter String filterExpression, @QueryParameter boolean reverseOrder) {
 
             // SECURITY-1022
             pItem.checkPermission(Job.CONFIGURE);
@@ -89,13 +89,14 @@ public class Nexus3ChoiceListProvider extends AbstractMavenArtifactChoiceListPro
             if (c != null) {
                 service.setCredentials(c.getUsername(), c.getPassword().getPlainText());
             }
-            return super.performTest(service, repositoryId, groupId, artifactId, packaging, classifier, reverseOrder);
+            return super.performTest(service, repositoryId, groupId, artifactId, packaging, classifier, inverseFilter, filterExpression, reverseOrder);
         }
 
         @Override
         protected Map<String, String> wrapTestConnection(IVersionReader pService, String pRepositoryId, String pGroupId, String pArtifactId, String pPackaging, String pClassifier,
-                boolean pReverseOrder) {
-            return readURL(pService, pRepositoryId, pGroupId, pArtifactId, pPackaging, pClassifier, pReverseOrder);
+                boolean pInverseFilter, String pFilterExpression, boolean pReverseOrder) {
+            return readURL(pService, pRepositoryId, pGroupId, pArtifactId, pPackaging, pClassifier,
+                pInverseFilter, pFilterExpression, pReverseOrder);
         }
 
         public FormValidation doCheckUrl(@QueryParameter String url) {

--- a/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3RestResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3RestResponse.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.maven_artifact_choicelistprovider.nexus3;
 
+import java.util.Arrays;
+
 /**
  * POJO for Nexus3 API.
  * 
@@ -21,16 +23,16 @@ public class Nexus3RestResponse {
     }
 
     public Item[] getItems() {
-        return items;
+        return Arrays.copyOf(items, items.length);
     }
 
     public void setItems(Item[] items) {
-        this.items = items;
+        this.items = Arrays.copyOf(items, items.length);
     }
 
     @Override
     public String toString() {
-        return "Nexus3RestResponse [continuationToken = " + continuationToken + ", items = " + items + "]";
+        return "Nexus3RestResponse [continuationToken = " + continuationToken + ", items = " + Arrays.toString(items) + "]";
     }
 
 }

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider/config.jelly
@@ -45,7 +45,7 @@ THE SOFTWARE.
         <f:checkbox />
     </f:entry>
     <f:entry title="${%Filter Expression}" field="filterExpression">
-        <f:textbox />
+        <f:textbox default=".*" />
     </f:entry>
      <f:entry title="${%Reverse Order}" field="reverseOrder">
         <f:checkbox />

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider/config.jelly
@@ -41,6 +41,12 @@ THE SOFTWARE.
     <f:entry title="${%Classifier}" field="classifier">
         <f:textbox />
     </f:entry>
+    <f:entry title="${%Inverse Filter}" field="inverseFilter">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="${%Filter Expression}" field="filterExpression">
+        <f:textbox />
+    </f:entry>
      <f:entry title="${%Reverse Order}" field="reverseOrder">
         <f:checkbox />
     </f:entry>
@@ -49,6 +55,6 @@ THE SOFTWARE.
         method="test"
         title="${%List Files Now}"
         progress="${%Checking...}"
-        with="url,credentialsId,groupId,artifactId,packaging,classifier,reverseOrder"
+        with="url,credentialsId,groupId,artifactId,packaging,classifier,inverseFilter,filterExpression,reverseOrder"
     />
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider/help-filterExpression.html
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider/help-filterExpression.html
@@ -1,0 +1,3 @@
+<div>
+Regular expression which filters the returned artifacts. Applied to the whole url. Allows extended grep syntax.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider/help-inverseFilter.html
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/artifactory/ArtifactoryChoiceListProvider/help-inverseFilter.html
@@ -1,0 +1,3 @@
+<div>
+Show only the results which do not match the regular expression specified in Filter Expression input field.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider/config.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
         <f:checkbox />
     </f:entry>
     <f:entry title="${%Filter Expression}" field="filterExpression">
-        <f:textbox />
+        <f:textbox default=".*" />
     </f:entry>
      <f:entry title="${%Reverse Order}" field="reverseOrder">
         <f:checkbox />

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider/config.jelly
@@ -35,14 +35,20 @@ THE SOFTWARE.
     <f:entry title="${%Classifier}" field="classifier">
         <f:textbox />
     </f:entry>
+    <f:entry title="${%Inverse Filter}" field="inverseFilter">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="${%Filter Expression}" field="filterExpression">
+        <f:textbox />
+    </f:entry>
      <f:entry title="${%Reverse Order}" field="reverseOrder">
         <f:checkbox />
     </f:entry>
-    
+
     <f:validateButton
         method="test"
         title="${%List Files Now}"
         progress="${%Checking...}"
-        with="groupId,artifactId,packaging,classifier,reverseOrder"
+        with="groupId,artifactId,packaging,classifier,inverseFilter,filterExpression,reverseOrder"
     />
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider/help-filterExpression.html
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider/help-filterExpression.html
@@ -1,0 +1,3 @@
+<div>
+Regular expression which filters the returned artifacts. Applied to the whole url. Allows extended grep syntax.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider/help-inverseFilter.html
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/central/MavenCentralChoiceListProvider/help-inverseFilter.html
@@ -1,0 +1,3 @@
+<div>
+Show only the results which do not match the regular expression specified in Filter Expression input field.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider/config.jelly
@@ -44,14 +44,20 @@ THE SOFTWARE.
     <f:entry title="${%Classifier}" field="classifier">
         <f:textbox />
     </f:entry>
+    <f:entry title="${%Inverse Filter}" field="inverseFilter">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="${%Filter Expression}" field="filterExpression">
+        <f:textbox />
+    </f:entry>
      <f:entry title="${%Reverse Order}" field="reverseOrder">
         <f:checkbox />
     </f:entry>
-    
+
     <f:validateButton
         method="test"
         title="${%List Files Now}"
         progress="${%Checking...}"
-        with="url,credentialsId,repositoryId,groupId,artifactId,packaging,classifier,reverseOrder"
+        with="url,credentialsId,repositoryId,groupId,artifactId,packaging,classifier,inverseFilter,filterExpression,reverseOrder"
     />
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider/config.jelly
@@ -48,7 +48,7 @@ THE SOFTWARE.
         <f:checkbox />
     </f:entry>
     <f:entry title="${%Filter Expression}" field="filterExpression">
-        <f:textbox />
+        <f:textbox default=".*" />
     </f:entry>
      <f:entry title="${%Reverse Order}" field="reverseOrder">
         <f:checkbox />

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider/help-filterExpression.html
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider/help-filterExpression.html
@@ -1,0 +1,3 @@
+<div>
+Regular expression which filters the returned artifacts. Applied to the whole url. Allows extended grep syntax.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider/help-inverseFilter.html
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus/NexusChoiceListProvider/help-inverseFilter.html
@@ -1,0 +1,3 @@
+<div>
+Show only the results which do not match the regular expression specified in Filter Expression input field.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider/config.jelly
@@ -44,6 +44,12 @@ THE SOFTWARE.
     <f:entry title="${%Classifier}" field="classifier">
         <f:textbox />
     </f:entry>
+    <f:entry title="${%Inverse Filter}" field="inverseFilter">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="${%Filter Expression}" field="filterExpression">
+        <f:textbox />
+    </f:entry>
      <f:entry title="${%Reverse Order}" field="reverseOrder">
         <f:checkbox />
     </f:entry>
@@ -52,6 +58,6 @@ THE SOFTWARE.
         method="test"
         title="${%List Files Now}"
         progress="${%Checking...}"
-        with="url,credentialsId,repositoryId,groupId,artifactId,packaging,classifier,reverseOrder"
+        with="url,credentialsId,repositoryId,groupId,artifactId,packaging,classifier,inverseFilter,filterExpression,reverseOrder"
     />
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider/config.jelly
@@ -48,7 +48,7 @@ THE SOFTWARE.
         <f:checkbox />
     </f:entry>
     <f:entry title="${%Filter Expression}" field="filterExpression">
-        <f:textbox />
+        <f:textbox default=".*" />
     </f:entry>
      <f:entry title="${%Reverse Order}" field="reverseOrder">
         <f:checkbox />

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider/help-filterExpression.html
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider/help-filterExpression.html
@@ -1,0 +1,3 @@
+<div>
+Regular expression which filters the returned artifacts. Applied to the whole url. Allows extended grep syntax.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider/help-inverseFilter.html
+++ b/src/main/resources/org/jenkinsci/plugins/maven_artifact_choicelistprovider/nexus3/Nexus3ChoiceListProvider/help-inverseFilter.html
@@ -1,0 +1,3 @@
+<div>
+Show only the results which do not match the regular expression specified in Filter Expression input field.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/ArtifactFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/ArtifactFilterTest.java
@@ -1,0 +1,91 @@
+package org.jenkinsci.plugins.maven_artifact_choicelistprovider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.PatternSyntaxException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ArtifactFilterTest {
+
+    // use sealed list to catch hidden modification attempts
+    private final List<String> testInput = Collections.unmodifiableList(Arrays.asList(
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/200.0.0-NEW",
+            "https://maven.example.com/content/repositories/snapshots-public/com/example/studio/example-studio-core/200.0.0-NEW-SNAPSHOT",
+            "https://maven.example.com/content/repositories/snapshots-public/com/example/studio/example-studio-core/1.9.0-SNAPSHOT",
+            "https://maven.example.com/content/repositories/snapshots-public/com/example/studio/example-studio-core/1.8.2-SNAPSHOT",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.8.1",
+            "https://maven.example.com/content/repositories/snapshots-public/com/example/studio/example-studio-core/1.8.1-SNAPSHOT",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.8.0",
+            "https://maven.example.com/content/repositories/snapshots-public/com/example/studio/example-studio-core/1.8.0-SNAPSHOT",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.8.0-BETA2",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.8.0-BETA",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.7.2",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.7.1",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.7.0"
+    ));
+
+    @Test
+    public void testFilterOutByInverse() {
+        boolean inverse = true;
+        String pattern = ".*NEW.*";
+        List<String> filteredList = AbstractMavenArtifactChoiceListProvider.filterArtifacts(testInput, inverse, pattern);
+
+        assertEquals("Expected only the 200.0.0-NEW and 200.0.0-NEW-SNAPSHOT removed from original list", testInput.size()-2, filteredList.size());
+    }
+
+    @Test
+    public void testFilterOutByAdvancedRegexp() {
+        boolean inverse = false;
+        String pattern = "(?!.*NEW).*";
+        List<String> filteredList = AbstractMavenArtifactChoiceListProvider.filterArtifacts(testInput, inverse, pattern);
+
+        assertEquals("Expected only the 200.0.0-NEW and 200.0.0-NEW-SNAPSHOT removed from original list", testInput.size()-2, filteredList.size());
+    }
+
+    @Test
+    public void testFilterIn() {
+        boolean inverse = false;
+        String pattern = ".*NEW.*";
+        List<String> filteredList = AbstractMavenArtifactChoiceListProvider.filterArtifacts(testInput, inverse, pattern);
+
+        assertEquals("Expected only the 200.0.0-NEW and 200.0.0-NEW-SNAPSHOT remained", 2, filteredList.size());
+    }
+
+    @Test
+    public void testFilterInWholeURL() {
+        boolean inverse = false;
+        String pattern = ".*/releases-public/.*NEW.*";
+        List<String> filteredList = AbstractMavenArtifactChoiceListProvider.filterArtifacts(testInput, inverse, pattern);
+
+        assertEquals("Expected only the 200.0.0-NEW remained", 1, filteredList.size());
+    }
+
+    @Test
+    public void testDefaultFilter() {
+        boolean inverse = false;
+        String pattern = ".*";
+        List<String> filteredList = AbstractMavenArtifactChoiceListProvider.filterArtifacts(testInput, inverse, pattern);
+
+        assertEquals("Expected all items from original list", testInput.size(), filteredList.size());
+    }
+
+    @Test
+    public void testInputsFromJobsBeforeTheUpgrade() {
+        boolean inverse = false;
+        String pattern = null;
+        List<String> filteredList = AbstractMavenArtifactChoiceListProvider.filterArtifacts(testInput, inverse, pattern);
+
+        assertEquals("Expected all items from original list to provide nice upgrade experience", testInput.size(), filteredList.size());
+    }
+
+    @Test(expected = PatternSyntaxException.class)
+    public void testInvalidRegexp() {
+        boolean inverse = true;
+        String pattern = "(";
+        AbstractMavenArtifactChoiceListProvider.filterArtifacts(testInput, inverse, pattern);
+    }
+}


### PR DESCRIPTION
Adding a functionality to further specify the selectable artifacts utilising java regexp on the originally returned list of long urls of the artifacts. Besides the implementation these are also provided: input validation, javadoc, junit test. 
Verification: mvn test passes 26 test, mvn install runs successfully, I was able to manually install the created hpi on jenkins plugin management UI. Also manually verified the change on a running jenkins service (both on newly created jobs and new run of non-modified existing jobs). 

Additionally I took the brevity to fix the unrelated spotbugs issues preventing mvn install to complete as part of this PR, but happy to revert if you think it should belong to somewhere else.

UI after the new input fields and demonstration of the filtering functionality during quicktest:
<img width="966" alt="jenkins_plugin_01" src="https://user-images.githubusercontent.com/20295893/107126957-33a7c600-68b3-11eb-8626-8766b14ac265.png">

Input validation of an invalid regular expression:
<img width="943" alt="jenkins_plugin_02" src="https://user-images.githubusercontent.com/20295893/107126959-386c7a00-68b3-11eb-94bf-832a317f414a.png">


If the changes in this PR looks too much, then please check the individual commits. I tried to make them on-by-one consumable.