### PR TITLE
Semantic versioning sorting on Nexus3ChoiceListProvider #16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,13 @@
             <version>2.11.4</version>
         </dependency>
 
+        <!-- Required for semantic version sorting -->
+        <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>semver4j</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/src/test/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/ArtifactSemanticSortingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/maven_artifact_choicelistprovider/ArtifactSemanticSortingTest.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.maven_artifact_choicelistprovider;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ArtifactSemanticSortingTest {
+
+    // use sealed list to catch hidden modification attempts
+    private final List<String> unsortedList = Collections.unmodifiableList(Arrays.asList(
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-beta.11",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-rc.1",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-alpha.1",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-beta.2",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-alpha.beta",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-beta",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-alpha",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.10.0",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.9.21",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/200.0.0",
+            "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/199.20.3"
+    ));
+
+    private final List<String> expectedSortedList = Collections.unmodifiableList(Arrays.asList(
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-alpha",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-alpha.1",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-alpha.beta",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-beta",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-beta.2",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-beta.11",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0-rc.1",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.0.0",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.9.21",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/1.10.0",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/199.20.3",
+        "https://maven.example.com/content/repositories/releases-public/com/example/studio/example-studio-core/200.0.0"
+        ));
+
+    @Test
+    public void testSemanticVersionSorting() {
+        List<String> sortedList = AbstractMavenArtifactChoiceListProvider.semanticVersionSortArtifacts(unsortedList);
+        assertEquals("Expected sorted list of URLS when provided an unsorted list", expectedSortedList, sortedList);
+    }
+}


### PR DESCRIPTION
As mentioned in [#16](https://github.com/jenkinsci/maven-artifact-choicelistprovider-plugin/issues/16) the sorting is currently ignoring the semantic versioning. Not sure if all providers support the correct sorting in their API, therefore I propose to do it after receiving the data from the server.
This feature is quite important, so we know that latest releases appear always on top.

Please review it and if all is good, please do a release as soon as possible.
